### PR TITLE
Tightened up resource control (queues, threads, channel messages).

### DIFF
--- a/pack.pl
+++ b/pack.pl
@@ -1,5 +1,5 @@
 name(jolog).
-version('0.0.1').
+version('0.0.2').
 title('Concurrency via join calculus').
 author('Michael Hendricks','michael@ndrix.org').
 packager('Michael Hendricks','michael@ndrix.org').


### PR DESCRIPTION
Hi Michael,
Your Jolog library has come in handy for something recently (I'll describe it in a separate email), but I had to make few changes to prevent thread, message queue and message leakage. Hopefully, these changes will make the library more robust. The extra debug lines were just for me to work out what was going on, obviously you can just take or leave those.
cheers,
Samer
